### PR TITLE
UI tweak: auto select option if list only contains one

### DIFF
--- a/workflow_initial_status/app/views/issues/new.html.erb
+++ b/workflow_initial_status/app/views/issues/new.html.erb
@@ -50,4 +50,5 @@
 
 <% content_for :header_tags do %>
     <%= robot_exclusion_tag %>
+    <%= javascript_include_tag 'workflow_initial_status', :plugin => 'workflow_initial_status' %>
 <% end %>

--- a/workflow_initial_status/assets/javascripts/workflow_initial_status.js
+++ b/workflow_initial_status/assets/javascripts/workflow_initial_status.js
@@ -1,0 +1,5 @@
+$(window).load(function() {
+  if ($('#issue_status_id').length === 1) {
+    $('#issue_status_id').val(1);
+  }
+});


### PR DESCRIPTION
I've forked and tweaked your plugin a little bit for my own personal use, not sure if you want to include this in the original or not..

The logic behind this is simple really:
- If there's only one available option, auto-select it.
- if there's more than one, don't auto-select anything.

This way, if I only allow new issues to go from "Initial" (as the default) to "New", with all other statuses listed after that, then creating a new issue instantly selects the status as "New".

This functionality could easily be made to always auto-select the first option, but if you did do that, I would suggest that it be a configurable option in the plugin.
